### PR TITLE
security: bump PyJWT to 2.12.0 in budget-approval (HIGH)

### DIFF
--- a/src/budget-approval/requirements.txt
+++ b/src/budget-approval/requirements.txt
@@ -3,5 +3,5 @@ uvicorn[standard]==0.30.0
 httpx==0.27.0
 azure-identity==1.17.0
 azure-ai-projects==2.0.0b1
-PyJWT[crypto]==2.9.0
+PyJWT[crypto]==2.12.0
 python-dotenv==1.0.0


### PR DESCRIPTION
Closes Dependabot alert #25 (HIGH).

**Vulnerability:** GHSA-752w-5fwx-jx9f — PyJWT accepts unknown `crit` header extensions.
**Fix:** Bump `PyJWT[crypto]` from 2.9.0 → 2.12.0 in `src/budget-approval/requirements.txt`.

This was the only remaining HIGH alert with an actually-vulnerable pin in the tree. Other HIGH alerts (#14, #17, #19, #21, #22) are flagged against `requirements-docs.txt`, which only contains mkdocs/mkdocs-material/pymdown-extensions — none of which transitively pull cryptography or PyJWT. Those are stale Dependabot artifacts from the `crowdstrike-mock → securityportal-mock` rename and will be dismissed as inaccurate.

🤖 Generated with [GitHub Copilot CLI](https://github.com/cli/cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>