### PR TITLE
security: sanitize exception text in HTTP responses (CodeQL stack-trace-exposure)

### DIFF
--- a/securityportal-mock/server.py
+++ b/securityportal-mock/server.py
@@ -142,14 +142,16 @@ async def auth_middleware(request, call_next):
         claims = _jwt_validator.validate_token(token)
     except ValueError as e:
         logger.error("JWT validation failed (JWKS): %s", e)
-        return JSONResponse(status_code=401, content={"detail": str(e)})
+        return JSONResponse(status_code=401, content={"detail": "invalid_token"})
     except Exception as e:
-        return JSONResponse(status_code=401, content={"detail": "Invalid token: %s" % e})
+        logger.exception("JWT validation failed (unexpected): %s", e)
+        return JSONResponse(status_code=401, content={"detail": "invalid_token"})
 
     try:
         role = _jwt_validator.check_role(claims)
     except PermissionError as e:
-        return JSONResponse(status_code=403, content={"detail": str(e)})
+        logger.warning("JWT role check denied: %s", e)
+        return JSONResponse(status_code=403, content={"detail": "forbidden"})
 
     # Viewers can read but not change risk levels or isolate agents
     if role == "viewer" and request.method.upper() in ("PUT", "POST"):
@@ -460,7 +462,7 @@ async def _push_risk_to_entra(agent_oid: str, risk_level: str) -> dict:
                 return {"entra_status": "error", "code": resp.status_code, "detail": resp.text[:200]}
     except Exception as e:
         logger.error(f"Failed to push risk to Entra: {e}")
-        return {"entra_status": "error", "detail": str(e)}
+        return {"entra_status": "error", "detail": "entra_push_failed"}
 
 
 @app.get("/api/agents")
@@ -495,7 +497,7 @@ async def list_agents():
             return {"error": "Risk store returned {0}".format(resp.status_code), "risks": {}}
     except Exception as e:
         logger.warning("Failed to query risk store: %s", e)
-        return {"error": str(e), "risks": {}, "count": 0}
+        return {"error": "risk_store_unreachable", "risks": {}, "count": 0}
 
 
 @app.put("/set-risk")
@@ -544,7 +546,7 @@ async def set_risk(spiffe_id: str, risk_level: str):
                         spiffe_id, risk_level, entra_status)
     except Exception as e:
         logger.error("Failed to push risk to sidecar: %s", e)
-        result["sidecar"] = {"error": str(e)}
+        result["sidecar"] = {"error": "sidecar_unreachable"}
 
     return result
 
@@ -621,7 +623,7 @@ async def isolate_agent(request: Request):
             )
             risk_result = resp.json() if resp.status_code == 200 else {"error": resp.text[:200]}
     except Exception as e:
-        risk_result = {"error": str(e)}
+        risk_result = {"error": "risk_update_failed"}
 
     result["layers"]["ca_risk"] = {
         "status": "success" if risk_result.get("status") == "updated" else "error",
@@ -703,7 +705,7 @@ async def isolate_agent(request: Request):
                     policy_result = {"status": "error", "detail": put_resp.text[:200]}
     except Exception as e:
         logger.error("Isolation policy update failed for %s: %s", agent_key, e)
-        policy_result = {"status": "error", "detail": str(e)}
+        policy_result = {"status": "error", "detail": "policy_update_failed"}
 
     result["layers"]["ca_policy"] = policy_result
     result["layers"]["rbac"] = {
@@ -749,7 +751,7 @@ async def isolate_agent(request: Request):
                                "note": "Agent was not in mTLS allow list"}
     except Exception as e:
         logger.error("Isolation mTLS update failed for %s: %s", agent_key, e)
-        mtls_result = {"status": "error", "detail": str(e)}
+        mtls_result = {"status": "error", "detail": "mtls_update_failed"}
 
     result["layers"]["mtls"] = mtls_result
 
@@ -879,7 +881,7 @@ async def restore_agent(request: Request):
                     policy_result = {"status": "error", "detail": put_resp.text[:200]}
     except Exception as e:
         logger.error("Restore policy failed for %s: %s", agent_key, e)
-        policy_result = {"status": "error", "detail": str(e)}
+        policy_result = {"status": "error", "detail": "policy_update_failed"}
 
     result["layers"]["ca_policy"] = policy_result
     result["layers"]["rbac"] = {"status": policy_result.get("status", "error")}
@@ -914,7 +916,7 @@ async def restore_agent(request: Request):
                                "note": "Agent was already in mTLS allow list"}
     except Exception as e:
         logger.error("Restore mTLS failed for %s: %s", agent_key, e)
-        mtls_result = {"status": "error", "detail": str(e)}
+        mtls_result = {"status": "error", "detail": "mtls_update_failed"}
 
     result["layers"]["mtls"] = mtls_result
 
@@ -933,7 +935,7 @@ async def restore_agent(request: Request):
             )
             risk_result = resp.json() if resp.status_code == 200 else {"error": resp.text[:200]}
     except Exception as e:
-        risk_result = {"error": str(e)}
+        risk_result = {"error": "risk_update_failed"}
 
     result["layers"]["ca_risk"] = {
         "status": "success" if risk_result.get("status") == "updated" else "error",

--- a/src/admin-control-plane/app.py
+++ b/src/admin-control-plane/app.py
@@ -227,6 +227,6 @@ async def admin_proxy(mgmt_path: str, request: Request):
     except httpx.RequestError as exc:
         logger.error("[%s] Admin proxy failed: %s", AGENT_NAME, exc)
         return JSONResponse(
-            {"error": "backend_mgmt_unreachable", "detail": str(exc)},
+            {"error": "backend_mgmt_unreachable"},
             status_code=502,
         )

--- a/src/budget-approval/app.py
+++ b/src/budget-approval/app.py
@@ -14,7 +14,7 @@ import secrets
 import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance
+from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance, sanitize_token_error
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(os.getenv("AGENT_NAME", "budget-approval"))
@@ -123,7 +123,7 @@ async def call_backend_raw(request: Request, method: str = "GET", path: str = "/
             "response": {
                 "error": "ca_policy_blocked",
                 "enforcement_layer": "conditional_access",
-                "detail": last_err,
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance (AADSTS53003).",
             },
         }
@@ -137,7 +137,7 @@ async def call_backend_raw(request: Request, method: str = "GET", path: str = "/
             "response": {
                 "error": "token_acquisition_failed",
                 "enforcement_layer": "authentication",
-                "detail": last_err or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Could not acquire an Entra token for authentication.",
             },
         }

--- a/src/budget-report/app.py
+++ b/src/budget-report/app.py
@@ -13,7 +13,7 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 import time as _time
-from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance
+from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance, sanitize_token_error
 
 try:
     import jwt as pyjwt
@@ -194,7 +194,7 @@ async def call_backend_raw(request: Request, method: str = "GET", path: str = "/
             "response": {
                 "error": "ca_policy_blocked",
                 "enforcement_layer": "conditional_access",
-                "detail": last_err,
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance (AADSTS53003).",
             },
         }
@@ -208,7 +208,7 @@ async def call_backend_raw(request: Request, method: str = "GET", path: str = "/
             "response": {
                 "error": "token_acquisition_failed",
                 "enforcement_layer": "authentication",
-                "detail": last_err or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Could not acquire an Entra token for authentication.",
             },
         }

--- a/src/demo-agent/app.py
+++ b/src/demo-agent/app.py
@@ -15,7 +15,7 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 import time as _time
-from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance
+from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance, sanitize_token_error
 
 try:
     import jwt as pyjwt
@@ -156,7 +156,7 @@ async def call_backend(action: str = "echo", message: str = "hello from caller")
         }
     except Exception as e:
         logger.error(f"[{agent_name}] Failed to call BudgetBackend: {e}")
-        return {"caller": agent_name, "target": "budget-backend", "http_status": 0, "error": str(e)}
+        return {"caller": agent_name, "target": "budget-backend", "http_status": 0, "error": "request_failed"}
 
 
 @app.post("/call-backend-raw")
@@ -187,7 +187,7 @@ async def call_backend_raw(method: str = "GET", path: str = "/budget/read", body
             "response": {
                 "error": "ca_policy_blocked",
                 "enforcement_layer": "conditional_access",
-                "detail": last_err,
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance (AADSTS53003).",
             },
         }
@@ -201,7 +201,7 @@ async def call_backend_raw(method: str = "GET", path: str = "/budget/read", body
             "response": {
                 "error": "token_acquisition_failed",
                 "enforcement_layer": "authentication",
-                "detail": last_err or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Could not acquire an Entra token for authentication.",
             },
         }
@@ -249,7 +249,7 @@ async def call_backend_raw(method: str = "GET", path: str = "/budget/read", body
             "method": method.upper(),
             "path": path,
             "http_status": 0,
-            "error": str(e),
+            "error": "request_failed",
         }
 
 
@@ -387,7 +387,7 @@ async def _call_target(target: str):
             "response": {
                 "error": "ca_policy_blocked" if is_ca_block else "token_acquisition_failed",
                 "enforcement_layer": "conditional_access" if is_ca_block else "authentication",
-                "detail": last_err or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance for this agent (AADSTS53003). "
                            "The agent is flagged as high-risk and the CA policy blocks high-risk agents."
                            if is_ca_block else "Could not acquire an Entra token for A2A authentication.",
@@ -410,7 +410,7 @@ async def _call_target(target: str):
         }
     except Exception:
         logger.exception(f"[{agent_name}] A2A call failed")
-        return {"caller": agent_name, "target": target, "http_status": 0, "error": str(e)}
+        return {"caller": agent_name, "target": target, "http_status": 0, "error": "request_failed"}
 
 
 @app.get("/call-agent")

--- a/src/employee-menus/app.py
+++ b/src/employee-menus/app.py
@@ -13,7 +13,7 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 import time as _time
-from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance
+from entra_token_exchange import get_entra_token_async, flush_cached_token, get_last_token_error, get_token_provenance, sanitize_token_error
 
 try:
     import jwt as pyjwt
@@ -198,7 +198,7 @@ async def call_backend_raw(request: Request, method: str = "GET", path: str = "/
             "response": {
                 "error": "ca_policy_blocked",
                 "enforcement_layer": "conditional_access",
-                "detail": last_err,
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance (AADSTS53003).",
             },
         }
@@ -212,7 +212,7 @@ async def call_backend_raw(request: Request, method: str = "GET", path: str = "/
             "response": {
                 "error": "token_acquisition_failed",
                 "enforcement_layer": "authentication",
-                "detail": last_err or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Could not acquire an Entra token for authentication.",
             },
         }
@@ -393,7 +393,7 @@ async def _call_target(target: str):
             "response": {
                 "error": "ca_policy_blocked" if is_ca_block else "token_acquisition_failed",
                 "enforcement_layer": "conditional_access" if is_ca_block else "authentication",
-                "detail": last_err or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance for this agent (AADSTS53003). "
                            "The agent is flagged as high-risk and the CA policy blocks high-risk agents."
                            if is_ca_block else "Could not acquire an Entra token for A2A authentication.",

--- a/src/shared/entra_token_exchange.py
+++ b/src/shared/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/shared/test_credential_providers.py
+++ b/src/shared/test_credential_providers.py
@@ -680,5 +680,27 @@ class TestTokenProvenance(unittest.TestCase):
         self.assertIsNone(mod._last_token_error)
 
 
+class TestSanitizeTokenError(unittest.TestCase):
+    """sanitize_token_error must strip exception text but preserve AADSTS codes."""
+
+    def test_aadsts_code_preserved(self):
+        mod = _fresh_import()
+        raw = "Agent Identity token exchange failed (400): AADSTS53003: Access blocked by Conditional Access"
+        self.assertEqual(mod.sanitize_token_error(raw), "AADSTS53003")
+
+    def test_generic_fallback_for_unrecognized_errors(self):
+        mod = _fresh_import()
+        raw = "ManagedIdentityCredential error: connection refused at /home/user/x.py:42"
+        self.assertEqual(mod.sanitize_token_error(raw), "token_acquisition_failed")
+
+    def test_none_returns_generic(self):
+        mod = _fresh_import()
+        self.assertEqual(mod.sanitize_token_error(None), "token_acquisition_failed")
+
+    def test_empty_string_returns_generic(self):
+        mod = _fresh_import()
+        self.assertEqual(mod.sanitize_token_error(""), "token_acquisition_failed")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses 23 CodeQL alerts in the `py/stack-trace-exposure` rule (alerts #3-#21, #27-#30).

## What

Stop leaking exception text to API consumers. Several handlers returned `str(e)`, `str(exc)`, or the full `_last_token_error` string in JSON response bodies. Those values include SDK-formatted exception messages with file paths, internal state, and stack-trace-derived data — useful reconnaissance for an attacker probing the API.

## How

1. **`src/shared/entra_token_exchange.py`** — add `sanitize_token_error()`. Extracts only the documented public AADSTS error code from the raw error string and returns `token_acquisition_failed` otherwise. Full details remain in server logs.
2. **4 agent services** (`demo-agent`, `budget-approval`, `employee-menus`, `budget-report`) — route `last_err` through the sanitizer in both CA-block and token-acquisition-failed paths.
3. **`src/demo-agent/app.py`** — replace `"error": str(e)` with generic `request_failed` in `/call-backend`, `/call-backend-raw`, and `_call_target`. Side fix: latent **NameError** in `_call_target` where `except Exception:` was missing `as e` but the body referenced `e`.
4. **`src/admin-control-plane/app.py`** — drop the raw `str(exc)` detail from `/admin` proxy error responses.
5. **`securityportal-mock/server.py`** — 12 sites replaced with stable error codes (`invalid_token`, `forbidden`, `sidecar_unreachable`, `policy_update_failed`, `mtls_update_failed`, `risk_update_failed`, `entra_push_failed`, `risk_store_unreachable`). Added missing server-side logging in the JWT `except Exception` arm.

Server-side logging (`logger.error/warning/exception`) continues to capture full exception detail for operators.

## Verification

- `python3 -m py_compile` clean on all touched files.
- `python3 -m unittest src.shared.test_credential_providers` — **36 tests pass** (including 4 new tests for `sanitize_token_error`).
- `python3 -m unittest src.test_agents` — **16 tests pass**.
- `grep -rn 'str(e)\|str(exc)' <touched-files>` — zero remaining exposures (all logger-only uses retained).

## Notes on the remaining alerts

After this lands, CodeQL should auto-close alerts #3-#21 and #27-#30 on next scan. The 3 HIGH alerts are being dismissed separately as false positives:

- **#1, #2** (`py/clear-text-logging-sensitive-data` in `scripts/entra_provisioning.py`): the printed values are tenant ID and client ID, both public Azure identifiers required by operators. CodeQL flags them because the tuple-unpacked source variable in the function signature is named `client_secret` (which is discarded via `_`).
- **#26** (`go/weak-sensitive-data-hashing` in `src/spiffe-proxy/internal/mgmt/server.go`): SHA-256 is used solely to normalize length for `subtle.ConstantTimeCompare` against a high-entropy operator-provisioned bearer token from an env var, not a user-chosen password. KDFs (bcrypt/argon2) are not appropriate here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>