### PR TITLE
ci(codeql): scan push and PRs on dev branch too

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   schedule:
     - cron: '35 6 * * 1'
 


### PR DESCRIPTION
Adds `dev` to both the `push` and `pull_request` branch filters in `.github/workflows/codeql.yml` so security analysis runs on the integration branch in addition to main. The weekly schedule is unchanged.

The `dev` branch has been created from `main` (https://github.com/microsoft/identity-spiffe/tree/dev).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>