### PR TITLE
Complete token error sanitization across agent containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,12 @@ jobs:
         run: pip install fastapi httpx uvicorn starlette "PyJWT[crypto]>=2.8.0"
 
       - name: Run agent tests
-        run: python -m unittest src/test_agents.py -v
+        run: |
+          python -m unittest \
+            src/test_agents.py \
+            src/test_token_error_contract.py \
+            src/shared/test_credential_providers.py \
+            -v
 
   docker-build:
     name: Docker build (spiffe-proxy)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Before changing authentication, deployment, or authorization code, read:
 
 - Read `docs/platform-learnings/agent-id-blueprints-and-users.md` before designing or changing any flow involving OAuth, OBO, Agent Identity, Agent Blueprints, Agent Users, MSAL, app registrations, redirect URIs, scopes, JWT validation, OIDC discovery, or PKCE.
 - Security paths fail closed. Missing Graph data, missing tokens, invalid JWTs, or unreachable control planes must not be interpreted as safe.
+- Use test-driven development for behavior changes: add or update a test, run it to confirm it fails for the intended reason, implement the smallest complete fix, then run the relevant suite again. Every security regression fix requires a regression test.
 - Test before committing. At minimum: Python syntax or relevant Python unit tests, relevant Go tests for `src/spiffe-proxy`, and `bash -n deploy.sh` when deployment scripts change.
 - Trace both sides of every dependency. If code reads an environment variable, secret, route, or config value, confirm the writer/source exists in the same change.
 - Do not use `azd deploy <service>` for agent services. Agent-side revisions consume join tokens and can break attestation. Use `./deploy.sh --skip-provision` or `./scripts/reattest.sh`.

--- a/src/admin-control-plane/entra_token_exchange.py
+++ b/src/admin-control-plane/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/budget-approval/app.py
+++ b/src/budget-approval/app.py
@@ -447,11 +447,12 @@ async def _call_target(target: str):
 
     headers = {"X-Caller-Agent": agent_name, "Content-Type": "application/json"}
     entra_token = await get_entra_token_async()
+    last_err = get_last_token_error()
     if entra_token:
         headers["Authorization"] = f"Bearer {entra_token}"
     else:
         # Token acquisition failed — check for specific CA policy block error
-        is_ca_block = get_last_token_error() and "AADSTS53003" in get_last_token_error()
+        is_ca_block = last_err and "AADSTS53003" in last_err
         return {
             "caller": agent_name,
             "target": target,
@@ -459,7 +460,7 @@ async def _call_target(target: str):
             "response": {
                 "error": "ca_policy_blocked" if is_ca_block else "token_acquisition_failed",
                 "enforcement_layer": "conditional_access" if is_ca_block else "authentication",
-                "detail": get_last_token_error() or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance for this agent (AADSTS53003). "
                            "The agent is flagged as high-risk and the CA policy blocks high-risk agents."
                            if is_ca_block else "Could not acquire an Entra token for A2A authentication.",

--- a/src/budget-approval/entra_token_exchange.py
+++ b/src/budget-approval/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/budget-backend/entra_token_exchange.py
+++ b/src/budget-backend/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/budget-report/app.py
+++ b/src/budget-report/app.py
@@ -384,11 +384,12 @@ async def _call_target(target: str):
 
     headers = {"X-Caller-Agent": agent_name, "Content-Type": "application/json"}
     entra_token = await get_entra_token_async()
+    last_err = get_last_token_error()
     if entra_token:
         headers["Authorization"] = f"Bearer {entra_token}"
     else:
         # Token acquisition failed — check for specific CA policy block error
-        is_ca_block = get_last_token_error() and "AADSTS53003" in get_last_token_error()
+        is_ca_block = last_err and "AADSTS53003" in last_err
         return {
             "caller": agent_name,
             "target": target,
@@ -396,7 +397,7 @@ async def _call_target(target: str):
             "response": {
                 "error": "ca_policy_blocked" if is_ca_block else "token_acquisition_failed",
                 "enforcement_layer": "conditional_access" if is_ca_block else "authentication",
-                "detail": get_last_token_error() or "No Entra token available",
+                "detail": sanitize_token_error(last_err),
                 "message": "Conditional Access policy denied token issuance for this agent (AADSTS53003). "
                            "The agent is flagged as high-risk and the CA policy blocks high-risk agents."
                            if is_ca_block else "Could not acquire an Entra token for A2A authentication.",

--- a/src/budget-report/entra_token_exchange.py
+++ b/src/budget-report/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/demo-agent/entra_token_exchange.py
+++ b/src/demo-agent/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/employee-menus/entra_token_exchange.py
+++ b/src/employee-menus/entra_token_exchange.py
@@ -40,6 +40,7 @@ import base64
 import json as _json
 import logging
 import os
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -327,6 +328,27 @@ def get_last_token_error():
     # type: () -> str | None
     """Return the error string from the most recent failed token acquisition."""
     return _last_token_error
+
+
+def sanitize_token_error(err):
+    # type: (str | None) -> str
+    """Reduce a raw token-error string to a safe, client-facing code.
+
+    Token errors stored in ``_last_token_error`` are formatted by us but
+    interpolate exception text from underlying SDKs (e.g.
+    ``f"ManagedIdentityCredential error: {exc}"``), which can leak stack
+    traces, file paths, or internal state if echoed in HTTP responses.
+
+    This helper returns the canonical, documented Microsoft Entra error
+    code (``AADSTSnnnnn``) when present — that code is intentionally
+    public and useful for client-side branching — and otherwise returns
+    a generic ``token_acquisition_failed``. Full details remain in
+    server-side logs.
+    """
+    if not err:
+        return "token_acquisition_failed"
+    match = re.search(r"AADSTS\d+", err)
+    return match.group(0) if match else "token_acquisition_failed"
 
 
 def get_token_provenance():

--- a/src/test_token_error_contract.py
+++ b/src/test_token_error_contract.py
@@ -1,0 +1,66 @@
+"""Regression tests for safe token-error handling in deployable agents."""
+
+import ast
+import unittest
+from pathlib import Path
+
+
+SRC_DIR = Path(__file__).resolve().parent
+TOKEN_MODULE_DIRS = (
+    "admin-control-plane",
+    "budget-approval",
+    "budget-backend",
+    "budget-report",
+    "demo-agent",
+    "employee-menus",
+)
+
+
+class TestTokenExchangeCopies(unittest.TestCase):
+    def test_service_copies_match_shared_module(self):
+        shared = (SRC_DIR / "shared" / "entra_token_exchange.py").read_bytes()
+
+        for service in TOKEN_MODULE_DIRS:
+            with self.subTest(service=service):
+                service_copy = (
+                    SRC_DIR / service / "entra_token_exchange.py"
+                ).read_bytes()
+                self.assertEqual(
+                    service_copy,
+                    shared,
+                    f"{service} token exchange module drifted from src/shared",
+                )
+
+
+class TestTokenErrorResponses(unittest.TestCase):
+    def test_apps_do_not_return_raw_token_errors(self):
+        unsafe_locations = []
+
+        for app_path in SRC_DIR.glob("*/app.py"):
+            tree = ast.parse(app_path.read_text(), filename=str(app_path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Dict):
+                    continue
+                for key, value in zip(node.keys, node.values):
+                    if not (
+                        isinstance(key, ast.Constant)
+                        and key.value == "detail"
+                    ):
+                        continue
+                    if any(
+                        isinstance(child, ast.Call)
+                        and isinstance(child.func, ast.Name)
+                        and child.func.id == "get_last_token_error"
+                        for child in ast.walk(value)
+                    ):
+                        unsafe_locations.append(f"{app_path}:{node.lineno}")
+
+        self.assertEqual(
+            unsafe_locations,
+            [],
+            "raw token errors are returned in client-facing detail fields",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds `sanitize_token_error` to every deployable service-local token exchange module
- sanitizes the two remaining direct A2A response paths
- adds a contract test that keeps service copies byte-for-byte synchronized with `src/shared`
- rejects client-facing `detail` fields that call `get_last_token_error()` directly
- runs the token-exchange provider tests in CI
- documents test-first TDD as a repository requirement

## TDD sequence

1. Added the regression contract test.
2. Confirmed it failed on raw token errors in `budget-report/app.py` and `budget-approval/app.py`.
3. Applied the minimal response sanitization fix.
4. Confirmed the same test passed.

## Local checks

- `python3 -m unittest src/test_token_error_contract.py -v`
- `python3 -m compileall -q src`
- `bash -n deploy.sh`
- `git diff --check`

Closes #24