### PR TITLE
Add explicit fail-closed sidecar risk provider

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1200,6 +1200,13 @@ fi
 AZD_VALUES_GRAPH=$(azd_env_load)
 GRAPH_CLIENT_ID=$(azd_env_get_from_blob "$AZD_VALUES_GRAPH" "ENTRA_AGENTID_CLIENT_ID")
 GRAPH_CLIENT_SECRET=$(azd_env_get_from_blob "$AZD_VALUES_GRAPH" "ENTRA_AGENTID_CLIENT_SECRET")
+AZD_CA_RISK_PROVIDER=$(azd_env_get_from_blob "$AZD_VALUES_GRAPH" "CA_RISK_PROVIDER")
+CA_RISK_PROVIDER="${CA_RISK_PROVIDER:-${AZD_CA_RISK_PROVIDER:-entra}}"
+if [ "$CA_RISK_PROVIDER" != "entra" ] && [ "$CA_RISK_PROVIDER" != "sidecar" ]; then
+    echo "ERROR: CA_RISK_PROVIDER must be 'entra' or 'sidecar' (got '$CA_RISK_PROVIDER')." >&2
+    exit 1
+fi
+echo "   CA risk provider: ${CA_RISK_PROVIDER}"
 if [ -n "${GRAPH_CLIENT_ID:-}" ] && [ -n "${GRAPH_CLIENT_SECRET:-}" ]; then
     echo "   Graph API credentials: ✓ (CA policy evaluation enabled)"
 else
@@ -1548,6 +1555,7 @@ for AGENT in "${AGENTS[@]}"; do
         export MI_CLIENT_ID_EMPLOYEE_MENUS="$MI_CLIENT_ID_EMPLOYEE_MENUS"
         export GRAPH_CLIENT_ID="$GRAPH_CLIENT_ID"
         export GRAPH_CLIENT_SECRET="$GRAPH_CLIENT_SECRET"
+        export CA_RISK_PROVIDER="$CA_RISK_PROVIDER"
         export ENTRA_AGENT_OID_BUDGET_REPORT="$ENTRA_AGENT_OID_BUDGET_REPORT"
         export ENTRA_AGENT_OID_BUDGET_APPROVAL="$ENTRA_AGENT_OID_BUDGET_APPROVAL"
         export ENTRA_AGENT_OID_ADMIN_CONTROL_PLANE="$ENTRA_AGENT_OID_ADMIN_CONTROL_PLANE"
@@ -1591,6 +1599,7 @@ oauth2_vars = {
 # Graph API credentials for CA policy evaluation (provisioner app)
 graph_client_id = os.environ.get("GRAPH_CLIENT_ID", "")
 graph_client_secret = os.environ.get("GRAPH_CLIENT_SECRET", "")
+ca_risk_provider = os.environ.get("CA_RISK_PROVIDER", "entra")
 
 with open(yaml_file) as f:
     app = yaml.safe_load(f)
@@ -1686,6 +1695,7 @@ for container in containers:
                        'A2A_TARGET_URL_BUDGET_APPROVAL',
                        'ADMIN_CONTROL_PLANE_ENDPOINT',
                        'RISK_STORE_URL',
+                       'CA_RISK_PROVIDER',
                        'GRAPH_CLIENT_ID', 'GRAPH_CLIENT_SECRET',
                        'ENTRA_AGENT_ID_BUDGET_REPORT', 'ENTRA_AGENT_ID_BUDGET_APPROVAL',
                        'ENTRA_AGENT_ID_EMPLOYEE_MENUS'}
@@ -1755,6 +1765,7 @@ for container in containers:
         if graph_client_id and graph_client_secret:
             env_list.append({'name': 'GRAPH_CLIENT_ID', 'value': graph_client_id})
             env_list.append({'name': 'GRAPH_CLIENT_SECRET', 'value': graph_client_secret})
+        env_list.append({'name': 'CA_RISK_PROVIDER', 'value': ca_risk_provider})
         container['env'] = env_list
         break
 
@@ -2232,6 +2243,7 @@ if [ -n "$PORTAL_AUTH_CLIENT_ID" ] || [ -n "$ADMIN_CP_URL" ]; then
         "ISP_ADMIN_GROUP_ID=${ISP_ADMIN_GROUP_ID}"
         "ISP_VIEWER_GROUP_ID=${ISP_VIEWER_GROUP_ID}"
         "PORTAL_MODE=cloud"
+        "CA_RISK_PROVIDER=${CA_RISK_PROVIDER}"
     )
     if [ -n "$STORAGE_ACCOUNT" ]; then
         portal_env_vars+=(

--- a/docs/architecture/deployment-sequence.md
+++ b/docs/architecture/deployment-sequence.md
@@ -1,6 +1,6 @@
 # Deployment Sequence
 
-> `deploy.sh` is the supported entrypoint. It is non-interactive by default, validates the live deployment unless `--no-verify` is passed, and only launches the portal when `--portal` is supplied. Real Entra CA provisioning is required by default; set `REQUIRE_REAL_CA=false` only when you intentionally want YAML fallback mode. For portal/Security Portal-only changes, use `--portal-only` to skip SPIRE work and avoid re-attestation.
+> `deploy.sh` is the supported entrypoint. It is non-interactive by default, validates the live deployment unless `--no-verify` is passed, and only launches the portal when `--portal` is supplied. Real Entra CA provisioning is required by default; set `REQUIRE_REAL_CA=false` only when you intentionally want YAML fallback mode. Entra ID Protection is the default agent-risk provider; set `CA_RISK_PROVIDER=sidecar` only for an explicit demo deployment whose tenant is not licensed for risky-agent APIs. For portal/Security Portal-only changes, use `--portal-only` to skip SPIRE work and avoid re-attestation.
 
 ```
 Step 1: azd provision        Step 2: Wait 90s        Step 2.5: Entra bootstrap
@@ -91,6 +91,7 @@ The verification suite now includes:
 - `--no-verify`: Skip the live test suite.
 - `--portal`: Launch the portal after a successful deploy.
 - `REQUIRE_REAL_CA=false`: Explicitly allow fallback CA mode when real Entra custom attribute or CA policy provisioning fails.
+- `CA_RISK_PROVIDER=sidecar`: Keep the real Entra CA policy and custom attributes, but read and write agent risk through the authenticated admin-control-plane store when Agent ID Protection is unavailable. Missing sidecar risk fails closed. The default is `entra`; there is no automatic fallback.
 
 ## Full Teardown and Redeploy
 

--- a/portal/app/services/ca.py
+++ b/portal/app/services/ca.py
@@ -37,7 +37,12 @@ class CAService:
             tag_task,
             ca_effective_task,
         )
-        risky_agents = await self.graph_client.fetch_risky_agents()
+        risk_provider = self.settings.ca_risk_provider
+        risky_agents = (
+            await self.graph_client.fetch_risky_agents()
+            if risk_provider == "entra"
+            else {}
+        )
         sp_oid_to_key = {}
         if risky_agents and self.graph_client.configured:
             for key, agent in self.settings.agents.items():
@@ -63,7 +68,7 @@ class CAService:
             agent = self.settings.agents.get(agent_key)
             spiffe_id = agent.spiffe_id if agent else (self.settings.control_plane.spiffe_id if agent_key == "admin-control-plane" else "")
             ca = entry.get("ca", {})
-            current_risk = "low"
+            current_risk = "unknown"
             for stored_id, risk_level in risk_store.items():
                 if stored_id == spiffe_id:
                     current_risk = risk_level
@@ -73,7 +78,12 @@ class CAService:
             effective_tag = graph_tag if graph_tag is not None else yaml_tag
             entra_risk = entra_risk_states.get(agent_key, {})
             entra_risk_level = entra_risk.get("risk_level", "none")
-            risk_in_sync = (current_risk == "low" and entra_risk_level in ("none", "low")) or current_risk == entra_risk_level
+            risk_in_sync = (
+                current_risk != "unknown"
+                if risk_provider == "sidecar"
+                else (current_risk == "low" and entra_risk_level in ("none", "low"))
+                or current_risk == entra_risk_level
+            )
             name = agent.name if agent else self.settings.control_plane.name
             tag_in_sync = graph_tag is None or graph_tag.lower() == yaml_tag.lower() if yaml_tag else True
             risk_policy_gap = admin_governance.get("enabled", False) and not blocked_levels
@@ -94,12 +104,14 @@ class CAService:
                     "entra_risk_level": entra_risk_level,
                     "entra_risk_state": entra_risk.get("risk_state", "notAtRisk"),
                     "risk_in_sync": risk_in_sync,
+                    "risk_provider": risk_provider,
                     "tag_matches_target": effective_tag.lower() == admin_governance.get("target_agent_tag", "").lower(),
                 }
             )
         return {
             "admin_governance": admin_governance,
             "agents": agent_statuses,
+            "risk_provider": risk_provider,
             "risk_store": risk_store,
             "entra_risk_states": entra_risk_states,
             "tag_store": tag_store,
@@ -108,10 +120,13 @@ class CAService:
 
     async def update_agent_risk(self, spiffe_id, risk_level, request_id):
         # type: (str, str, str) -> Dict[str, Any]
-        agent_oid = self._resolve_agent_oid(spiffe_id)
-        if not agent_oid:
-            raise PortalError(400, "entra_agent_not_resolved", "Could not resolve Entra agent identity for the selected agent")
-        entra_result = await self.graph_client.push_agent_risk(agent_oid, risk_level)
+        risk_provider = self.settings.ca_risk_provider
+        entra_result = None
+        if risk_provider == "entra":
+            agent_oid = self._resolve_agent_oid(spiffe_id)
+            if not agent_oid:
+                raise PortalError(400, "entra_agent_not_resolved", "Could not resolve Entra agent identity for the selected agent")
+            entra_result = await self.graph_client.push_agent_risk(agent_oid, risk_level)
         sidecar_result = await self.admin_client.put_json(
             "agent-risk",
             {"spiffe_id": spiffe_id, "risk_level": risk_level},
@@ -123,7 +138,12 @@ class CAService:
                 flush_result = await self.agent_invoker.flush_token(agent.url, self.settings.mgmt_api_key, request_id)
                 flush_result["flushed"] = agent_key
                 break
-        return {**sidecar_result, "entra": entra_result, "token_flush": flush_result}
+        return {
+            **sidecar_result,
+            "entra": entra_result,
+            "risk_provider": risk_provider,
+            "token_flush": flush_result,
+        }
 
     async def flush_all_tokens(self, request_id):
         # type: (str) -> Dict[str, Any]

--- a/portal/app/settings.py
+++ b/portal/app/settings.py
@@ -89,6 +89,7 @@ class PortalSettings:
     azure_tenant_id: str = ""
     graph_client_id: str = ""
     graph_client_secret: str = ""
+    ca_risk_provider: str = "entra"
     policy_store_provider: str = "file"
     policy_store_path: str = ""
     policy_store_account_url: str = ""
@@ -213,6 +214,14 @@ async def load_settings(config_path):
     azure_tenant_id = os.getenv("AZURE_TENANT_ID", "")
     graph_client_id = os.getenv("GRAPH_CLIENT_ID", "") or os.getenv("ENTRA_AGENTID_CLIENT_ID", "")
     graph_client_secret = os.getenv("GRAPH_CLIENT_SECRET", "") or os.getenv("ENTRA_AGENTID_CLIENT_SECRET", "")
+    ca_risk_provider = os.getenv("CA_RISK_PROVIDER", "entra").lower()
+    if ca_risk_provider not in {"entra", "sidecar"}:
+        raise PortalError(
+            500,
+            "settings_invalid",
+            "CA_RISK_PROVIDER must be 'entra' or 'sidecar'",
+            {"value": ca_risk_provider},
+        )
     appinsights_connection_string = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
     azure_client_id = os.getenv("AZURE_CLIENT_ID", "")
 
@@ -254,6 +263,7 @@ async def load_settings(config_path):
             azure_tenant_id=azure_tenant_id,
             graph_client_id=graph_client_id,
             graph_client_secret=graph_client_secret,
+            ca_risk_provider=ca_risk_provider,
             policy_store_provider=policy_store_provider,
             policy_store_account_url=policy_store_account_url,
             policy_store_container=policy_store_container,
@@ -297,6 +307,7 @@ async def load_settings(config_path):
         azure_tenant_id=azure_tenant_id,
         graph_client_id=graph_client_id,
         graph_client_secret=graph_client_secret,
+        ca_risk_provider=ca_risk_provider,
         policy_store_provider=os.getenv("POLICY_CONFIG_STORE_PROVIDER", "file"),
         policy_store_path=os.getenv(
             "POLICY_CONFIG_FILE",

--- a/portal/index.html
+++ b/portal/index.html
@@ -4111,7 +4111,7 @@ function renderOAuth(root) {
   // ── CA Admin Governance (Layer 4b) ──
   var govTitle = document.createElement('div'); govTitle.className = 'section-title'; govTitle.style.marginTop = '12px'; govTitle.textContent = 'Layer 4b: Admin Governance'; root.appendChild(govTitle);
   var govSubtitle = document.createElement('div'); govSubtitle.style.cssText = 'font-size:12px;color:var(--text-2);margin-bottom:16px';
-  govSubtitle.textContent = 'Agent tags, risk levels, and CA enforcement state from v5.0 policy + sidecar risk store + Entra ID Protection'; root.appendChild(govSubtitle);
+  govSubtitle.textContent = 'Agent tags, risk levels, and CA enforcement state from v5.0 policy'; root.appendChild(govSubtitle);
 
   var caBtnWrap = document.createElement('div'); caBtnWrap.style.cssText = 'display:flex;gap:8px;margin-bottom:16px';
   var loadCaBtn = document.createElement('button'); loadCaBtn.className = 'btn-refresh'; loadCaBtn.textContent = 'Load CA Status';
@@ -4140,6 +4140,18 @@ function renderOAuth(root) {
   if (state.caGovData) {
     var gov = state.caGovData.admin_governance || {};
     var govAgents = state.caGovData.agents || [];
+    var riskProvider = state.caGovData.risk_provider || 'entra';
+    var providerBadge = document.createElement('div'); providerBadge.style.cssText = 'margin-bottom:12px';
+    var providerLabel = document.createElement('span'); providerLabel.className = 'badge';
+    if (riskProvider === 'sidecar') {
+      providerLabel.style.cssText = 'background:var(--amber-light);color:var(--amber);border:1px solid var(--amber-border)';
+      providerLabel.textContent = 'Risk source: authenticated sidecar store (demo mode)';
+    } else {
+      providerLabel.style.cssText = 'background:var(--green-light);color:var(--green);border:1px solid var(--green-border)';
+      providerLabel.textContent = 'Risk source: Entra ID Protection';
+    }
+    providerBadge.appendChild(providerLabel);
+    root.appendChild(providerBadge);
 
     // Admin Governance summary
     var govGrid = document.createElement('div'); govGrid.style.cssText = 'display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin:16px 0';
@@ -4229,21 +4241,21 @@ function renderOAuth(root) {
         else { matchBadge.style.cssText = 'background:var(--amber-light);color:var(--amber);border:1px solid var(--amber-border)'; matchBadge.textContent = 'Mismatch'; }
         td4.appendChild(matchBadge); tr.appendChild(td4);
 
-        // Risk level — authoritative from Entra ID Protection (Graph riskyAgents API)
+        // Risk level from the configured authoritative provider.
         var td5 = document.createElement('td'); td5.style.cssText = 'padding:8px 12px';
-        var entraRisk = ag.entra_risk_level || 'none';
-        var entraState = ag.entra_risk_state || 'notAtRisk';
-        var entraLabel = entraRisk === 'none' ? 'safe' : entraRisk;
-        var entraColor = entraRisk === 'high' ? 'var(--red)' : entraRisk === 'medium' ? 'var(--amber)' : 'var(--green)';
-        var entraBg = entraRisk === 'high' ? 'var(--red-light,#fde8e8)' : entraRisk === 'medium' ? 'var(--amber-light)' : 'var(--green-light)';
+        var displayedRisk = riskProvider === 'sidecar' ? (ag.current_risk || 'unknown') : (ag.entra_risk_level || 'none');
+        var displayedState = riskProvider === 'sidecar' ? '' : (ag.entra_risk_state || 'notAtRisk');
+        var displayedLabel = displayedRisk === 'none' ? 'safe' : displayedRisk;
+        var displayedColor = displayedRisk === 'high' ? 'var(--red)' : displayedRisk === 'medium' ? 'var(--amber)' : displayedRisk === 'unknown' ? 'var(--text-3)' : 'var(--green)';
+        var displayedBg = displayedRisk === 'high' ? 'var(--red-light,#fde8e8)' : displayedRisk === 'medium' ? 'var(--amber-light)' : displayedRisk === 'unknown' ? 'var(--bg)' : 'var(--green-light)';
         var entraBadge = document.createElement('span'); entraBadge.className = 'badge';
-        entraBadge.style.cssText = 'background:' + entraBg + ';color:' + entraColor + ';border:1px solid ' + entraColor;
-        entraBadge.textContent = entraLabel;
+        entraBadge.style.cssText = 'background:' + displayedBg + ';color:' + displayedColor + ';border:1px solid ' + displayedColor;
+        entraBadge.textContent = displayedLabel;
         td5.appendChild(entraBadge);
-        if (entraState !== 'notAtRisk' && entraRisk !== 'none') {
+        if (displayedState !== 'notAtRisk' && displayedState && displayedRisk !== 'none') {
           var stateNote = document.createElement('span');
           stateNote.style.cssText = 'margin-left:6px;font-size:10px;color:var(--text-3)';
-          stateNote.textContent = entraState;
+          stateNote.textContent = displayedState;
           td5.appendChild(stateNote);
         }
         tr.appendChild(td5);
@@ -4262,10 +4274,12 @@ function renderOAuth(root) {
         // Actions: risk dropdown + apply
         var td7 = document.createElement('td'); td7.style.cssText = 'padding:8px 12px';
         var riskSelect = document.createElement('select'); riskSelect.style.cssText = 'font-size:11px;padding:3px 6px;border:1px solid var(--border);border-radius:4px;margin-right:4px';
-        var currentEntraRisk = (ag.entra_risk_level === 'none' || !ag.entra_risk_level) ? 'low' : ag.entra_risk_level;
+        var currentRisk = riskProvider === 'sidecar'
+          ? ag.current_risk
+          : ((ag.entra_risk_level === 'none' || !ag.entra_risk_level) ? 'low' : ag.entra_risk_level);
         ['low', 'medium', 'high'].forEach(function(lvl) {
           var opt = document.createElement('option'); opt.value = lvl; opt.textContent = lvl;
-          if (lvl === currentEntraRisk) opt.selected = true;
+          if (lvl === currentRisk) opt.selected = true;
           riskSelect.appendChild(opt);
         });
         td7.appendChild(riskSelect);
@@ -4277,8 +4291,12 @@ function renderOAuth(root) {
             btnEl.textContent = 'Updating...'; btnEl.disabled = true;
             api('/agent-risk', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ spiffe_id: agentData.spiffe_id, risk_level: newRisk }) })
               .then(function(result) {
-                var entraStatus = result && result.entra ? result.entra.entra_status : 'unknown';
-                btnEl.textContent = entraStatus === 'success' ? 'Sent to Entra' : 'Sent (Entra: ' + entraStatus + ')';
+                if (result && result.risk_provider === 'sidecar') {
+                  btnEl.textContent = 'Sent to sidecar store';
+                } else {
+                  var entraStatus = result && result.entra ? result.entra.entra_status : 'unknown';
+                  btnEl.textContent = entraStatus === 'success' ? 'Sent to Entra' : 'Sent (Entra: ' + entraStatus + ')';
+                }
                 btnEl.style.background = 'var(--green-light)'; btnEl.style.color = 'var(--green)'; btnEl.style.borderColor = 'var(--green)';
                 // Delay re-fetch to allow Entra propagation
                 setTimeout(function() {

--- a/portal/tests/test_clients.py
+++ b/portal/tests/test_clients.py
@@ -8,6 +8,7 @@ from portal.app.clients.admin_control_plane import AdminControlPlaneClient
 from portal.app.clients.agent_invoker import AgentInvokerClient
 from portal.app.clients.graph import GraphClient
 from portal.app.errors import PortalError
+from portal.app.services.ca import CAService
 
 
 def _request(method, url):
@@ -70,6 +71,81 @@ class TestGraphClient(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(ctx.exception.status_code, 502)
         self.assertEqual(ctx.exception.error_code, "graph_attribute_lookup_failed")
+
+
+class TestCAService(unittest.IsolatedAsyncioTestCase):
+    async def test_sidecar_status_uses_sidecar_risk_without_graph_query(self):
+        agent = SimpleNamespace(
+            name="BudgetReport",
+            spiffe_id="spiffe://example/budget-report",
+            entra_agent_id="agent-id",
+        )
+        settings = SimpleNamespace(
+            ca_risk_provider="sidecar",
+            agents={"budget-report": agent},
+            control_plane=SimpleNamespace(name="AdminControlPlane", spiffe_id=""),
+        )
+
+        async def get_json(path, _request_id):
+            responses = {
+                "policy": {
+                    "version": "5.0",
+                    "policies": [{"name": "budget-report", "ca": {}}],
+                },
+                "agent-risk": {
+                    "risks": {"spiffe://example/budget-report": "high"},
+                },
+                "agent-tags": {"tags": {}},
+                "ca-policy-effective": {
+                    "blocked_risk_levels": ["high"],
+                },
+            }
+            return responses[path]
+
+        graph_client = SimpleNamespace(
+            configured=True,
+            fetch_risky_agents=AsyncMock(),
+        )
+        service = CAService(
+            settings,
+            SimpleNamespace(get_json=get_json),
+            graph_client,
+            SimpleNamespace(),
+        )
+
+        result = await service.get_ca_status("request-id")
+
+        self.assertEqual(result["risk_provider"], "sidecar")
+        self.assertEqual(result["agents"][0]["current_risk"], "high")
+        graph_client.fetch_risky_agents.assert_not_awaited()
+
+    async def test_sidecar_risk_provider_does_not_query_unlicensed_graph_api(self):
+        settings = SimpleNamespace(
+            ca_risk_provider="sidecar",
+            agents={},
+        )
+        admin_client = SimpleNamespace(
+            put_json=AsyncMock(return_value={"status": "updated"})
+        )
+        graph_client = SimpleNamespace(
+            push_agent_risk=AsyncMock(),
+        )
+        service = CAService(
+            settings,
+            admin_client,
+            graph_client,
+            SimpleNamespace(),
+        )
+        service._resolve_agent_oid = lambda _spiffe_id: "agent-id"
+
+        result = await service.update_agent_risk(
+            "spiffe://example/agent",
+            "high",
+            "request-id",
+        )
+
+        self.assertEqual(result["risk_provider"], "sidecar")
+        graph_client.push_agent_risk.assert_not_awaited()
 
 
 class TestAgentInvokerClient(unittest.IsolatedAsyncioTestCase):

--- a/portal/tests/test_settings.py
+++ b/portal/tests/test_settings.py
@@ -101,6 +101,41 @@ class TestPortalSettings(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(settings.policy_store_container, "portal-policy-configs")
         self.assertEqual(settings.control_plane.url, "https://admin-control-plane.example")
 
+    async def test_cloud_settings_preserve_explicit_sidecar_risk_provider(self):
+        env = {
+            "PORTAL_MODE": "cloud",
+            "ADMIN_CP_URL": "https://admin-control-plane.example",
+            "MGMT_API_KEY": "super-secret",
+            "AUTH_CLIENT_ID": "portal-client-id",
+            "ISP_ADMIN_GROUP_ID": "admin-group-id",
+            "ISP_VIEWER_GROUP_ID": "viewer-group-id",
+            "AZURE_TENANT_ID": "tenant-id",
+            "POLICY_CONFIG_BLOB_ACCOUNT_URL": "https://storage.example.blob.core.windows.net/",
+            "POLICY_CONFIG_BLOB_CONTAINER": "portal-policy-configs",
+            "POLICY_CONFIG_BLOB_NAME": "policy-configs.json",
+            "CA_RISK_PROVIDER": "sidecar",
+        }
+        discovery = {
+            "agents": {},
+            "control_plane": {
+                "url": "https://admin-control-plane.example",
+            },
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with patch(
+                "portal.app.settings._discover_cloud_agents",
+                new=AsyncMock(return_value=discovery),
+            ):
+                settings = await load_settings("unused.json")
+
+        self.assertEqual(settings.ca_risk_provider, "sidecar")
+
+    async def test_invalid_risk_provider_fails_fast(self):
+        with patch.dict(os.environ, {"CA_RISK_PROVIDER": "unsafe-default"}, clear=False):
+            with self.assertRaises(PortalError) as ctx:
+                await load_settings("unused.json")
+        self.assertEqual(ctx.exception.error_code, "settings_invalid")
+
     async def test_cloud_agent_discovery_failure_is_fatal(self):
         response = httpx.Response(
             503,

--- a/src/admin-control-plane/ca_evaluator.py
+++ b/src/admin-control-plane/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/budget-approval/app.py
+++ b/src/budget-approval/app.py
@@ -372,11 +372,11 @@ def _spiffe_id_matches_caller(spiffe_id: str, caller_identifier: str) -> bool:
     return False
 
 
-async def _query_risk_store(caller_identifier: str) -> str:
+async def _query_risk_store(caller_identifier: str):
     """Query the dedicated admin control-plane for a caller's risk level."""
     mgmt_base = RISK_STORE_URL or ADMIN_CONTROL_PLANE_ENDPOINT
     if not mgmt_base:
-        return "low"
+        return None
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             headers = {}
@@ -408,7 +408,7 @@ async def _query_risk_store(caller_identifier: str) -> str:
                                 return risk
     except Exception as e:
         logger.warning(f"Risk store query failed: {e}")
-    return "low"
+    return None
 
 
 async def _query_caller_ca(caller_identifier: str) -> dict:
@@ -557,9 +557,10 @@ async def approval_status(request: Request):
     # then check caller's risk from Entra ID Protection riskyAgents API.
     # Entra is the sole source of truth. FAIL CLOSED if unavailable.
     caller_oid = jwt_claims["oid"] if jwt_claims else caller_id
+    fallback_risk = await _query_risk_store(caller_id)
     from ca_evaluator import get_evaluator
     ca_eval = get_evaluator()
-    blocked, ca_details = await ca_eval.should_block_caller(caller_oid)
+    blocked, ca_details = await ca_eval.should_block_caller(caller_oid, fallback_risk=fallback_risk)
     if blocked:
         logger.warning(f"[{agent_name}] A2A blocked by CA policy: {caller_id} details={ca_details}")
         return JSONResponse({

--- a/src/budget-approval/ca_evaluator.py
+++ b/src/budget-approval/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/budget-backend/ca_evaluator.py
+++ b/src/budget-backend/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/budget-report/app.py
+++ b/src/budget-report/app.py
@@ -316,9 +316,9 @@ def _spiffe_id_matches_caller(spiffe_id: str, caller_identifier: str) -> bool:
     return False
 
 
-async def _query_risk_store(caller_identifier: str) -> str:
+async def _query_risk_store(caller_identifier: str):
     if not ADMIN_CONTROL_PLANE_ENDPOINT:
-        return "low"
+        return None
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             headers = {}
@@ -346,7 +346,7 @@ async def _query_risk_store(caller_identifier: str) -> str:
                                 return risk
     except Exception as e:
         logger.warning(f"Risk store query failed: {e}")
-    return "low"
+    return None
 
 
 async def _query_caller_ca(caller_identifier: str) -> dict:

--- a/src/budget-report/ca_evaluator.py
+++ b/src/budget-report/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/demo-agent/app.py
+++ b/src/demo-agent/app.py
@@ -307,9 +307,9 @@ def _spiffe_id_matches_caller(spiffe_id: str, caller_identifier: str) -> bool:
     return False
 
 
-async def _query_risk_store(caller_identifier: str) -> str:
+async def _query_risk_store(caller_identifier: str):
     if not ADMIN_CONTROL_PLANE_ENDPOINT:
-        return "low"
+        return None
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             headers = {}
@@ -337,7 +337,7 @@ async def _query_risk_store(caller_identifier: str) -> str:
                                 return risk
     except Exception as e:
         logger.warning(f"Risk store query failed: {e}")
-    return "low"
+    return None
 
 
 async def _query_caller_ca(caller_identifier: str) -> dict:

--- a/src/demo-agent/ca_evaluator.py
+++ b/src/demo-agent/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/employee-menus/app.py
+++ b/src/employee-menus/app.py
@@ -313,9 +313,9 @@ def _spiffe_id_matches_caller(spiffe_id: str, caller_identifier: str) -> bool:
     return False
 
 
-async def _query_risk_store(caller_identifier: str) -> str:
+async def _query_risk_store(caller_identifier: str):
     if not ADMIN_CONTROL_PLANE_ENDPOINT:
-        return "low"
+        return None
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             headers = {}
@@ -343,7 +343,7 @@ async def _query_risk_store(caller_identifier: str) -> str:
                                 return risk
     except Exception as e:
         logger.warning(f"Risk store query failed: {e}")
-    return "low"
+    return None
 
 
 async def _query_caller_ca(caller_identifier: str) -> dict:

--- a/src/employee-menus/ca_evaluator.py
+++ b/src/employee-menus/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/shared/ca_evaluator.py
+++ b/src/shared/ca_evaluator.py
@@ -31,6 +31,7 @@ GRAPH_CLIENT_ID = os.getenv("GRAPH_CLIENT_ID", "")
 GRAPH_CLIENT_SECRET = os.getenv("GRAPH_CLIENT_SECRET", "")
 AZURE_TENANT_ID = os.getenv("AZURE_TENANT_ID", "")
 GRAPH_BETA = "https://graph.microsoft.com/beta"
+CA_RISK_PROVIDER = os.getenv("CA_RISK_PROVIDER", "entra").lower()
 
 # Cache TTLs
 CA_POLICY_CACHE_TTL = int(os.getenv("CA_POLICY_CACHE_TTL", "60"))
@@ -266,7 +267,8 @@ class CAEvaluator:
 
         Args:
             caller_oid: The Entra agent identity OID (appId) of the caller.
-            fallback_risk: IGNORED — kept for API compat but Entra is sole source.
+            fallback_risk: Risk from the authenticated sidecar store. Used only
+                when CA_RISK_PROVIDER=sidecar.
 
         Returns:
             (blocked: bool, details: dict) where details includes enforcement info.
@@ -305,6 +307,32 @@ class CAEvaluator:
             details["agent_risk"] = "n/a"
             details["risk_source"] = "entra_ca_policy"
             return False, details
+
+        if CA_RISK_PROVIDER == "sidecar":
+            if fallback_risk not in ("none", "low", "medium", "high"):
+                details["enforcement_source"] = "fail_closed"
+                details["reason"] = "Cannot determine caller risk from sidecar store — DENY (fail closed)"
+                details["agent_risk"] = "unknown"
+                details["risk_source"] = "unavailable"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["agent_risk"] = fallback_risk
+            details["risk_source"] = "sidecar"
+            details["enforcement_source"] = "sidecar_risk_store"
+            if fallback_risk in blocked_levels:
+                details["reason"] = "high_risk_agent_blocked"
+                details["enforcement_layer"] = "conditional_access"
+                return True, details
+            details["reason"] = "risk_level_not_blocked"
+            return False, details
+
+        if CA_RISK_PROVIDER != "entra":
+            details["enforcement_source"] = "fail_closed"
+            details["reason"] = "Unknown CA risk provider — DENY (fail closed)"
+            details["agent_risk"] = "unknown"
+            details["risk_source"] = "unavailable"
+            details["enforcement_layer"] = "conditional_access"
+            return True, details
 
         # Fetch caller's risk from Entra ID Protection (resolves appId -> SP OID)
         caller_risk = await self.fetch_agent_risk(caller_oid)

--- a/src/shared/test_ca_evaluator.py
+++ b/src/shared/test_ca_evaluator.py
@@ -1,0 +1,107 @@
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+
+MODULE_PATH = Path(__file__).with_name("ca_evaluator.py")
+
+
+def load_evaluator(risk_provider):
+    env = {
+        "CA_RISK_PROVIDER": risk_provider,
+        "GRAPH_CLIENT_ID": "client-id",
+        "GRAPH_CLIENT_SECRET": "client-secret",
+        "AZURE_TENANT_ID": "tenant-id",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        spec = importlib.util.spec_from_file_location(
+            "ca_evaluator_under_test",
+            MODULE_PATH,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+class CARiskProviderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_sidecar_provider_allows_explicit_low_risk(self):
+        module = load_evaluator("sidecar")
+        evaluator = module.CAEvaluator()
+        evaluator.fetch_ca_policies = AsyncMock(
+            return_value=[
+                {
+                    "id": "policy-id",
+                    "state": "enabled",
+                    "conditions": {"agentIdRiskLevels": ["high"]},
+                    "grantControls": {"builtInControls": ["block"]},
+                }
+            ]
+        )
+        evaluator.fetch_agent_risk = AsyncMock()
+
+        blocked, details = await evaluator.should_block_caller(
+            "caller-id",
+            fallback_risk="low",
+        )
+
+        self.assertFalse(blocked)
+        self.assertEqual(details["risk_source"], "sidecar")
+        evaluator.fetch_agent_risk.assert_not_awaited()
+
+    async def test_sidecar_provider_blocks_high_and_missing_risk(self):
+        module = load_evaluator("sidecar")
+        evaluator = module.CAEvaluator()
+        evaluator.fetch_ca_policies = AsyncMock(
+            return_value=[
+                {
+                    "id": "policy-id",
+                    "state": "enabled",
+                    "conditions": {"agentIdRiskLevels": ["high"]},
+                    "grantControls": {"builtInControls": ["block"]},
+                }
+            ]
+        )
+
+        high_blocked, high_details = await evaluator.should_block_caller(
+            "caller-id",
+            fallback_risk="high",
+        )
+        missing_blocked, missing_details = await evaluator.should_block_caller(
+            "caller-id",
+            fallback_risk=None,
+        )
+
+        self.assertTrue(high_blocked)
+        self.assertEqual(high_details["risk_source"], "sidecar")
+        self.assertTrue(missing_blocked)
+        self.assertEqual(missing_details["enforcement_source"], "fail_closed")
+
+    async def test_entra_provider_ignores_sidecar_fallback(self):
+        module = load_evaluator("entra")
+        evaluator = module.CAEvaluator()
+        evaluator.fetch_ca_policies = AsyncMock(
+            return_value=[
+                {
+                    "id": "policy-id",
+                    "state": "enabled",
+                    "conditions": {"agentIdRiskLevels": ["high"]},
+                    "grantControls": {"builtInControls": ["block"]},
+                }
+            ]
+        )
+        evaluator.fetch_agent_risk = AsyncMock(return_value=None)
+
+        blocked, details = await evaluator.should_block_caller(
+            "caller-id",
+            fallback_risk="low",
+        )
+
+        self.assertTrue(blocked)
+        self.assertEqual(details["risk_source"], "unavailable")
+        evaluator.fetch_agent_risk.assert_awaited_once_with("caller-id")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve Entra ID Protection as the default risk source
- add an explicit authenticated sidecar risk provider for tenants without risky-agent API licensing
- fail closed when sidecar risk is missing or unreachable
- expose the active provider in the portal and direct A2A enforcement results
- wire and validate `CA_RISK_PROVIDER` through the supported deployment flow

## Validation
- 43 portal unit tests passed
- 53 shared unit tests passed
- `bash -n deploy.sh` passed
- fresh Azure deployment completed successfully
- live enforcement matrix passed 22/22
- portal and Security Portal health endpoints return HTTP 200

Closes #26